### PR TITLE
Update markdown generator (submodule)

### DIFF
--- a/MarkdownTableMakerAddOn.gs
+++ b/MarkdownTableMakerAddOn.gs
@@ -27,8 +27,8 @@
 
 /**
  * name     : MarkdownTableMakerAddOn.gs
- * version  : 11
- * updated  : 2016-09-08
+ * version  : 12
+ * updated  : 2017-06-20
  * license  : http://unlicense.org/ The Unlicense
  * git      : https://github.com/pffy/googledocs-addon-markdowntablefive
  *
@@ -36,7 +36,7 @@
 var product = {
 
   "name": "MarkdownTableMaker",
-  "version": "11",
+  "version": "12",
 
   "license": "This is free, libre and open source software.",
   "licenseUrl": "http://unlicense.org/",
@@ -104,6 +104,11 @@ function saveAsMarkdownFromSheet() {
   return drv.getUrl();
 }
 
+// make Markdown safe to embed inside <textarea>
+function escapeSpecialCharacters_(markdown) {
+  return markdown.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+}
+
 // converts Range, displays sidebar
 function convertRange_() {
 
@@ -115,7 +120,7 @@ function convertRange_() {
     + '<div class="wrapper">'
     + 'Range Only<br/>'
     + '  <textarea READONLY>'
-            + convertMarkdownFromRange_().trim() + '</textarea><br/>'
+            + escapeSpecialCharacters_(convertMarkdownFromRange_().trim()) + '</textarea><br/>'
     + '  <button class="action" onClick="saveMarkdownFromRange();">Save As Markdown</button><br/>'
     + '  <button onClick="updateFromRange();">Update</button>'
     + '  <div id="msg">&nbsp;</div>'
@@ -137,7 +142,7 @@ function convertSheet_() {
     + '<div class="wrapper">'
     + 'Entire Sheet<br/>'
     + '  <textarea READONLY>'
-            + convertMarkdownFromSheet_().trim() + '</textarea><br/>'
+            + escapeSpecialCharacters_(convertMarkdownFromSheet_().trim()) + '</textarea><br/>'
     + '  <button class="action" onClick="saveMarkdownFromSheet();">Save As Markdown</button><br/>'
     + '  '
     + '  <div id="msg">&nbsp;</div>'


### PR DESCRIPTION
Entity-escape the markdown inserted inside `<textarea>`.

The previous markdown generator would output things like `&amp#124;` so that it would show up as `&#124;` in the `<textarea>` but that means if the markdown was saved to your Google Drive, it would contain the escaped entities.

There could also be other things in the markdown that would cause issues for the `<textarea>`, for example letting one of the cells contain `</textarea>`.